### PR TITLE
Support of no_delete and make encrypt key truly optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # S3 Encrypt Resource for [Concourse CI](http://concourse.ci)
 
-Resource to upload/download GPG encrypted files to S3. Unlike the [the official S3 Resource](https://github.com/concourse/s3-resource), this resource can upload or download multiple files using the `aws s3 sync` command.
+Resource to upload/download GPG encrypted files to S3. Unlike the [the official S3 Resource](https://github.com/concourse/s3-resource), this resource can upload or download multiple files using the `aws s3 sync` command. 
+
+By default the sync operation uses `--delete` flag to ensure that files in the destination are removed - Use the `no_delete` option to change this behaviour.
 
 ## Usage
 
@@ -20,6 +22,7 @@ resources:
     secret_access_key: {{aws-secret-key}}
     bucket: {{aws-bucket}}
     encryption_key: {{encryption_key}}
+    no_delete: true
 jobs:
 - name: <job name>
   plan:

--- a/assets/check
+++ b/assets/check
@@ -29,6 +29,7 @@ if [ -n "${AWS_ACCESS_KEY_ID}" ] && [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
   export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
 fi
 
+endpoint_url=""
 if [ -n "${endpoint_url}" ]; then
   endpoint_opt="--endpoint-url=${endpoint_url}"
 fi
@@ -38,6 +39,7 @@ if [ "${use_v4}" = "true" ];then
   aws configure set default.s3.signature_version s3v4
 fi
 
+ssl_verification_opt=""
 if [ "${skip_ssl_verification}" = "true" ]; then
   ssl_verification_opt="--no-verify-ssl"
   export PYTHONWARNINGS="ignore:Unverified HTTPS request"
@@ -56,7 +58,7 @@ fi
 # Consider the most recent LastModified timestamp as the most recent version.
 # We don't want options encapsulated in quotes as they are space-separated switches
 # shellcheck disable=SC2086
-version=$(aws "${ssl_verification_opt}" s3 "${endpoint_opt}" ls --recursive "s3://${bucket}/${path}" | grep "${suffix}${with_enc}\$" | sha1sum | awk '{print $1}')
+version=$(aws ${ssl_verification_opt} s3 ${endpoint_opt} ls --recursive "s3://${bucket}/${path}" | grep "${suffix}${with_enc}\$" | sha1sum | awk '{print $1}')
 
 jq -n "[
   {

--- a/assets/check
+++ b/assets/check
@@ -49,10 +49,7 @@ if [ -n "${ca_bundle}" ]; then
 fi
 
 with_enc=""
-if [ ! "${encryption_key}" = "" ];then
-  echo "Encrypting with GnuPG..."
-  find "${source}/${path}" -type f -name "*${suffix}" -exec \
-    gpg --yes --batch --passphrase="${encryption_key}" -c {} \;
+if [ "${encryption_key}" != "" ];then
   with_enc=".gpg"
 fi
 

--- a/assets/check
+++ b/assets/check
@@ -17,6 +17,7 @@ region="$(echo "$payload" | jq -r '.source.region // "us-east-1"')"
 use_v4="$(echo "$payload" | jq -r '.source.use_v4 // ""')"
 skip_ssl_verification="$(echo "$payload" | jq -r '.source.skip_ssl_verification // ""')"
 ca_bundle="$(echo "$payload" | jq -r '.source.ca_bundle // ""')"
+encryption_key="$(echo "${payload}" | jq -r '.source.encryption_key // ""')"
 
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "$payload" | jq -r '.source.access_key_id')
@@ -47,10 +48,18 @@ if [ -n "${ca_bundle}" ]; then
   export AWS_CA_BUNDLE=/tmp/ca.pem
 fi
 
+with_enc=""
+if [ ! "${encryption_key}" = "" ];then
+  echo "Encrypting with GnuPG..."
+  find "${source}/${path}" -type f -name "*${suffix}" -exec \
+    gpg --yes --batch --passphrase="${encryption_key}" -c {} \;
+  with_enc=".gpg"
+fi
+
 # Consider the most recent LastModified timestamp as the most recent version.
 # We don't want options encapsulated in quotes as they are space-separated switches
 # shellcheck disable=SC2086
-version=$(aws "${ssl_verification_opt}" s3 "${endpoint_opt}" ls --recursive "s3://${bucket}/${path}" | grep "${suffix}.gpg\$" | sha1sum | awk '{print $1}')
+version=$(aws "${ssl_verification_opt}" s3 "${endpoint_opt}" ls --recursive "s3://${bucket}/${path}" | grep "${suffix}${with_enc}\$" | sha1sum | awk '{print $1}')
 
 jq -n "[
   {

--- a/assets/in
+++ b/assets/in
@@ -55,8 +55,9 @@ if [ -n "${ca_bundle}" ]; then
   export AWS_CA_BUNDLE=/tmp/ca.pem
 fi
 
+with_enc=""
 [ -z "${encryption_key}" ] || with_enc=".gpg"
-options="--exclude='*' --include='*${suffix}${with_enc}' --delete"
+options="--exclude='*' --include='*${suffix}${with_enc}'"
 
 echo "Downloading from S3..."
 # We don't want options encapsulated in quotes as they are space-separated switches

--- a/assets/out
+++ b/assets/out
@@ -81,7 +81,7 @@ echo "...done."
 
 # We don't want options encapsulated in quotes as they are space-separated switches
 # shellcheck disable=SC2086
-version=$(aws ${ssl_verification_opt} ${endpoint_opt} s3 ls --recursive "s3://${bucket}/${path}" | grep "${suffix}.gpg\$" | sha1sum | awk '{print $1}')
+version=$(aws ${ssl_verification_opt} ${endpoint_opt} s3 ls --recursive "s3://${bucket}/${path}" | grep "${suffix}${with_enc}\$" | sha1sum | awk '{print $1}')
 
 jq -n "{
   version: {

--- a/assets/out
+++ b/assets/out
@@ -27,6 +27,7 @@ suffix=$(echo "${payload}" | jq -r '.source.suffix // ""')
 encryption_key="$(echo "${payload}" | jq -r '.source.encryption_key // ""')"
 skip_ssl_verification="$(echo "$payload" | jq -r '.source.skip_ssl_verification // ""')"
 ca_bundle="$(echo "$payload" | jq -r '.source.ca_bundle // ""')"
+no_delete="$(echo "$payload" | jq -r '.source.no_delete // ""')"
 
 # export for `aws` cli
 AWS_ACCESS_KEY_ID=$(echo "${payload}" | jq -r '.source.access_key_id')
@@ -66,8 +67,13 @@ if [ ! "${encryption_key}" = "" ];then
   with_enc=".gpg"
 fi
 
+delete_flag=""
+if [ -z "${no_delete}" -o "${no_delete}" = "false" ]; then
+  delete_flag="--delete"
+fi
+
 echo "Uploading to S3..."
-options="--exclude='*' --include='*${suffix}${with_enc}' --delete"
+options="--exclude='*' --include='*${suffix}${with_enc}' ${delete_flag}"
 # We don't want options encapsulated in quotes as they are space-separated switches
 # shellcheck disable=SC2086
 eval aws ${ssl_verification_opt} s3 sync "${source}/${path}" "s3://${bucket}/${path}" ${endpoint_opt} ${options}


### PR DESCRIPTION
# What is this PR about?

This resource currently has the `--delete` option for the `aws s3 sync` command hardcoded in place. This option may not be desireable for all users as it results in deletions on the S3 bucket which may be unexpected, so this PR adds a `no_delete` option which can be used to override this default behaviour.

Additionally, there appears to be a bug in the generation of the `version` number that concourse uses for its resources. Currently there is a `|grep "${suffix}.gpg\$"` included in the command for generating the version, but this would only be valid for users who are specifying the '___optional___' `encrpyt_key` parameter. For non-encrypting users this will result in the version number always being identical (the sha1sum of an empty string)

This PR addresses the issues highlighted above.

# How to review this PR
Please review the code changes within this PR to check for mistakes/errors/malicious code etc.
Please test that the resource still works correctly for your use case(s)
If happy with the changes, please merge this PR.

# Who can review this PR?
Anyone except @jimconner