### PR TITLE
Don't overwrite endpoint_url when testing it's value. endpoint_opt sh…

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -29,7 +29,7 @@ if [ -n "${AWS_ACCESS_KEY_ID}" ] && [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
   export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
 fi
 
-endpoint_url=""
+endpoint_opt=""
 if [ -n "${endpoint_url}" ]; then
   endpoint_opt="--endpoint-url=${endpoint_url}"
 fi


### PR DESCRIPTION
The test for checking whether endpoint_opt was incorrectly blanking the same endpoint_url variable that it then goes on to test to see whether it is empty.

The correct code should have set endpoint_opt as empty variable, tested endpoint_url and then set endpoint_opt accordingly.

This PR fixes that problem.