### PR TITLE
Removed exit on invalid path

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -69,7 +69,7 @@ timeouts="--cli-read-timeout 5 --cli-connect-timeout 5"
 
 echo "Checking path in S3..."
 # shellcheck disable=SC2086
-aws ${timeouts} ${endpoint_opt} ${ssl_verification_opt} s3 ls "s3://${bucket}/${path}" > /dev/null || ( echo "Path check failed, check path provided exists and creds are valid." && exit 1 )
+aws ${timeouts} ${endpoint_opt} ${ssl_verification_opt} s3 ls "s3://${bucket}/${path}" > /dev/null || echo "Path check failed, check path provided exists and creds are valid."
 
 # Consider the most recent LastModified timestamp as the most recent version.
 # We don't want options encapsulated in quotes as they are space-separated switches

--- a/assets/in
+++ b/assets/in
@@ -76,7 +76,7 @@ timeouts="--cli-read-timeout 5 --cli-connect-timeout 5"
 
 echo "Checking path in S3..."
 # shellcheck disable=SC2086
-aws ${endpoint_opt} ${ssl_verification_opt} ${timeouts} s3 ls "s3://${bucket}/${path}" > /dev/null || ( echo "Path check failed, check path provided exists and creds are valid." && exit 1 )
+aws ${endpoint_opt} ${ssl_verification_opt} ${timeouts} s3 ls "s3://${bucket}/${path}" > /dev/null || echo "Path check failed, check path provided exists and creds are valid."
 
 echo "Downloading from S3..."
 # We don't want options encapsulated in quotes as they are space-separated switches

--- a/assets/out
+++ b/assets/out
@@ -86,7 +86,7 @@ timeouts="--cli-read-timeout 5 --cli-connect-timeout 5"
 
 echo "Checking path in S3..."
 # shellcheck disable=SC2086
-aws ${endpoint_opt} ${ssl_verification_opt} ${timeouts} s3 ls "s3://${bucket}/${path}" > /dev/null || ( echo "Path check failed, check path provided exists and creds are valid." && exit 1 )
+aws ${endpoint_opt} ${ssl_verification_opt} ${timeouts} s3 ls "s3://${bucket}/${path}" > /dev/null || echo "Path check failed, check path provided exists and creds are valid."
 
 echo "Uploading to S3..."
 options="--exclude='*' --include='*${suffix}${with_enc}' ${delete_flag}"


### PR DESCRIPTION
### What
We have a scenario where there will be an invalid path
after a nuke of an environment. Exit has been removed but have left the
echo to still help troubleshoot if path being invalid is not intentional.

### How
Check diffs and merge 

(already tested and script no longer exits if that command fails)
### Who
Not Stuart