### PR TITLE
Quotes were affecting space-separated variables

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -86,7 +86,7 @@ fi
 echo "Downloading from S3..."
 # We don't want options encapsulated in quotes as they are space-separated switches
 # shellcheck disable=SC2086
-eval aws ${ssl_verification_opt} ${endpoint_opt} ${timeouts} s3 sync "s3://${bucket}/${path} ${dest} ${options}"
+eval aws ${ssl_verification_opt} ${endpoint_opt} ${timeouts} s3 sync s3://${bucket}/${path} ${dest} ${options}
 echo "...done."
 
 if [ ! "${encryption_key}" = "" ];then


### PR DESCRIPTION
This appears to have been introduced by accident around 8 months ago. The arguments for s3 bucket, dest and options were all enclosed within a single set of quotes which would cause them to be interpretted as a single argument. Not sure if this is having any detrimental impact as we're passing the whole command to 'eval' which theoretically will handle as multiple arguments anyway.

Not sure why were were using eval in the first place... maybe due to issues with quoting. 

Whatever the case, the quotes crept in, and the comment immediately above within the code is explaining how we specifically do not want to have them in quotes.

This PR removes the quotes.