### PR TITLE
Added metadata to improve concourse logging info

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -8,13 +8,14 @@ set -o nounset
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
+pip install -r /opt/resource/requirements.txt
+
 dest=${1}
 
 if [ -z "${dest}" ]; then
   echo "usage: $0 <path/to/volume>"
   exit 1
 fi
-#######################################
 
 # parse incoming config data
 payload=$(cat)
@@ -99,8 +100,11 @@ if [ ! "${encryption_key}" = "" ];then
   echo "...done."
 fi
 
-version=$(echo "${payload}" | jq -re '.version')
+file_info=$(aws --endpoint-url ${endpoint_url} ${ssl_verification_opt} ${timeouts} --output json s3api list-objects --bucket ${bucket} --prefix ${path} | jq '[.Contents[] | {"file_name": .Key, "last_changed": .LastModified, "file_size": .Size}]')
 
-jq -n "{
-  version: ${version}
-}" >&3
+# shellcheck disable=SC2236
+if [ ! -z "${file_info}" ]; then
+  echo "${payload}" | /opt/resource/metadata.py "${file_info}" >&3
+else
+  echo "${payload}" | /opt/resource/metadata.py >&3
+fi

--- a/assets/in
+++ b/assets/in
@@ -8,8 +8,6 @@ set -o nounset
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
-pip install -r /opt/resource/requirements.txt
-
 dest=${1}
 
 if [ -z "${dest}" ]; then
@@ -102,9 +100,4 @@ fi
 
 file_info=$(aws --endpoint-url ${endpoint_url} ${ssl_verification_opt} ${timeouts} --output json s3api list-objects --bucket ${bucket} --prefix ${path} | jq '[.Contents[] | {"file_name": .Key, "last_changed": .LastModified, "file_size": .Size}]')
 
-# shellcheck disable=SC2236
-if [ ! -z "${file_info}" ]; then
-  echo "${payload}" | /opt/resource/metadata.py "${file_info}" >&3
-else
-  echo "${payload}" | /opt/resource/metadata.py >&3
-fi
+echo "${payload}" | /opt/resource/metadata.py "${file_info}" >&3

--- a/assets/metadata.py
+++ b/assets/metadata.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
-import os
-import requests
+
 import sys
 import json
-import dpath.util
 import dateutil.parser as dp
 from datetime import datetime
 

--- a/assets/metadata.py
+++ b/assets/metadata.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+import os
+import requests
+import sys
+import json
+import dpath.util
+import dateutil.parser as dp
+from datetime import datetime
+
+def extract_vars_from_payload(payload):
+    try:
+        bucket = payload['source']['bucket']
+        endpoint = payload['source']['endpoint']
+        path = payload['source']['path']
+        version_ref = payload['version']['ref']
+    except (KeyError, TypeError) as e:
+        print("Error processing payload from concourse")
+        print("Required source parameters are bucket, endpoint, path and version_ref")
+        print(e)
+        sys.exit(1)
+    return(bucket, endpoint, path, version_ref)
+
+
+if __name__ == "__main__":
+    try:
+        payload = sys.stdin.read()
+        file_info = ""
+        if len(sys.argv) > 1:
+            file_info=json.loads(sys.argv[1])
+
+        bucket, endpoint, path, version_ref = extract_vars_from_payload(json.loads(payload))
+
+        metadata = [{"name": "bucket", "value": bucket}, {"name": "endpoint", "value": endpoint}, {"name": "path", "value": path}]
+
+        if file_info != "":
+            for file in file_info:
+                new_time = dp.isoparse(file['last_changed'])
+                file['last_changed'] = new_time.strftime("%d/%m/%Y, %H:%M:%S %Z")
+                metadata.append({"name": f"{file['file_name']}", "value" : f"Size: {file['file_size']} bytes, Last-modified: {file['last_changed']}"})
+
+        print(json.dumps({ "version": { "ref": version_ref }, "metadata": metadata }))
+
+    except Exception as e:
+        print("Unexpected error encountered in `main`")
+        print(e)
+        sys.exit(1)

--- a/assets/metadata.py
+++ b/assets/metadata.py
@@ -18,19 +18,14 @@ def extract_vars_from_payload(payload):
         sys.exit(1)
     return(bucket, endpoint, path, version_ref)
 
-
 if __name__ == "__main__":
     try:
         payload = sys.stdin.read()
-        file_info = ""
-        if len(sys.argv) > 1:
-            file_info=json.loads(sys.argv[1])
-
         bucket, endpoint, path, version_ref = extract_vars_from_payload(json.loads(payload))
-
         metadata = [{"name": "bucket", "value": bucket}, {"name": "endpoint", "value": endpoint}, {"name": "path", "value": path}]
 
-        if file_info != "":
+        if sys.argv[1] != "":
+            file_info=json.loads(sys.argv[1])
             for file in file_info:
                 new_time = dp.isoparse(file['last_changed'])
                 file['last_changed'] = new_time.strftime("%d/%m/%Y, %H:%M:%S %Z")

--- a/assets/requirements.txt
+++ b/assets/requirements.txt
@@ -1,2 +1,0 @@
-dpath
-requests

--- a/assets/requirements.txt
+++ b/assets/requirements.txt
@@ -1,0 +1,2 @@
+dpath
+requests


### PR DESCRIPTION
## What

Current s3 resource didn’t always show much information on files changed, bucket or endpoint related info, when resource was passed through jobs.

This change enables the s3 encrypt resource to output resource metadata,
including attributes like bucket, s3 endpoint, path to file in bucket,
and filenames (with respective size and last modified date with
timezone)

Currently this metadata information is only viewable in the GET of a
resource from a job on concourse, as the changes were only implemented in the assets/in script.

## How to review

Can use the locally built and pushed image (in a test dockerhub repo) in a pipeline that uses the s3-encrypt resource using the following:
```
source:
    repository: <docker registry>/fidelityinternational/concourse-s3-encrypt-resource-test
    tag: 2.0.33
```

Check on concourse that you can see a metadata card under the GET step of the resource, and that the information looks accurate/ is what you'd expect from that specific concourse.

Check diffs and merge if happy. Once merged I will retag and check image is built in dockerhub, and remove test repo we used.

## Who 

Not @StuWill or @sushant-kapoor17 

Signed-off-by: Sushant Kapoor <sushant.kapoor@fil.com>